### PR TITLE
Add Input.init

### DIFF
--- a/SemanticUI/Elements/Input.elm
+++ b/SemanticUI/Elements/Input.elm
@@ -8,7 +8,7 @@ module SemanticUI.Elements.Input exposing (..)
 
 # Input properties
 
-@docs Config
+@docs Config, init
 
 -}
 
@@ -28,6 +28,21 @@ type alias Config msg =
     , inverted : Bool
     , fluid : Bool
     , size : Size
+    }
+
+
+{-| The initial config of an input field. Corresponds to just using `class="ui input"` in Semantic UI.
+-}
+init : Config msg
+init =
+    { attributes = []
+    , focus = False
+    , loading = False
+    , error = False
+    , transparent = False
+    , inverted = False
+    , fluid = False
+    , size = Medium
     }
 
 


### PR DESCRIPTION
Hey, thanks for the work on this. Just playing around with it a bit and noticed there was no `init` for `Input` yet.

By the way would you say it's currently the best out of the various Semantic UI Elm libs out there? Also, could you clarify the license, is it BSD3 like it says in the elm-package.json?