### PR TITLE
Add Button.disabled

### DIFF
--- a/SemanticUI/Elements/Button.elm
+++ b/SemanticUI/Elements/Button.elm
@@ -24,6 +24,7 @@ module SemanticUI.Elements.Button
         , icon
         , active
         , attached
+        , disabled
         )
 
 {-|
@@ -114,6 +115,12 @@ A button can show it is currently the active user selection.
 
 @docs active
 
+## Disabled
+
+A button can show it is currently unable to be interacted with
+
+@docs disabled
+
 -}
 
 import Html exposing (..)
@@ -162,12 +169,20 @@ type alias Config msg =
     , floated : Maybe Floated
     , active : Bool
     , attached : Maybe Attached
+    , disabled : Bool
     }
 
 
 attached : Maybe Attached -> Config msg -> Config msg
 attached attached model =
     { model | attached = attached }
+
+
+{-| Whether or not this button is disabled
+-}
+disabled : Bool -> Config msg -> Config msg
+disabled disabled model =
+    { model | disabled = disabled }
 
 
 {-| Whether or not this button is fluid
@@ -216,6 +231,7 @@ init =
     , icon = Nothing
     , active = False
     , attached = Nothing
+    , disabled = False
     }
 
 
@@ -297,7 +313,7 @@ viewAs :
     -> Config msg
     -> List (Html msg)
     -> Html msg
-viewAs element { emphasis, hiddenContent, basic, inverted, loading, fluid, attributes, size, icon, iconSide, floated, active, attached } label =
+viewAs element { emphasis, hiddenContent, basic, inverted, loading, fluid, attributes, size, icon, iconSide, floated, active, attached, disabled } label =
     let
         contentWithIcon =
             List.concat
@@ -327,6 +343,7 @@ viewAs element { emphasis, hiddenContent, basic, inverted, loading, fluid, attri
                         , ( "labeled", labelled )
                         , ( "icon", icon /= Nothing )
                         , ( "active", active )
+                        , ( "disabled", disabled )
                         ]
                   , sizeClass size
                   ]
@@ -373,6 +390,7 @@ viewAs element { emphasis, hiddenContent, basic, inverted, loading, fluid, attri
                                 FadeAnimation ->
                                     [ class "fade" ]
                             ]
+                , [ Html.Attributes.disabled disabled ]
                 ]
             )
         <|

--- a/SemanticUI/Elements/Button.elm
+++ b/SemanticUI/Elements/Button.elm
@@ -53,6 +53,12 @@ Usage example:
 
 @docs Config, init, attributes
 
+## Attached
+
+A button can be attached to the top or bottom of other content.
+
+@docs attached
+
 ## Emphasis
 
 A button can be formatted to show different levels of emphasis.
@@ -173,6 +179,8 @@ type alias Config msg =
     }
 
 
+{-| Whether or not this button is attached to the top or bottom of other content
+-}
 attached : Maybe Attached -> Config msg -> Config msg
 attached attached model =
     { model | attached = attached }


### PR DESCRIPTION
This adds `Button.disabled`. Using `Button.disabled True` not only sets the `disabled` attribute of the button, but also adds the `disabled` class to it.

Currently, adding the `disabled` class in addition to the `disabled` attribute appears to make no difference to a button's behavior or appearance. However, the examples in the Semantic UI docs do add the `disabled` class to disabled buttons, so this class may be required in future. It is also more convenient to use `Button.disabled` than it is to set the `disabled` attribute directly, and it is more obvious that this is the Right Way to disable a button.

This pull request also fixes some missing docs for the 'attached' property (just because I needed to get elm-make to quit whining about it before I could test the new code).