### PR TITLE
Add attributes option for grid columns

### DIFF
--- a/SemanticUI/Collections/Grid.elm
+++ b/SemanticUI/Collections/Grid.elm
@@ -199,8 +199,8 @@ grid { padded, columnsPerRow, attributes, equalWidth, divided, doubling, stackab
 
 {-| Wrap Html as a grid column.
 -}
-column : Column.Config -> List (Html msg) -> Column msg
-column { textAlignment, width } =
+column : Column.Config msg -> List (Html msg) -> Column msg
+column { textAlignment, width, attributes } =
     Column
         << div
             (List.concat
@@ -256,5 +256,6 @@ column { textAlignment, width } =
                                 "sixteen wide"
                   , textAlignmentClass textAlignment
                   ]
+                  , attributes
                 ]
             )

--- a/SemanticUI/Collections/Grid/Column.elm
+++ b/SemanticUI/Collections/Grid/Column.elm
@@ -21,7 +21,7 @@ A column can vary in width taking up more than a single grid column.
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import SemanticUI exposing (ColumnCount(..), TextAlignment(..), textAlignmentClass)
+import SemanticUI exposing (TextAlignment(..), ColumnCount(..), textAlignmentClass)
 
 
 {-| The configuration of a column.

--- a/SemanticUI/Collections/Grid/Column.elm
+++ b/SemanticUI/Collections/Grid/Column.elm
@@ -21,35 +21,44 @@ A column can vary in width taking up more than a single grid column.
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import SemanticUI exposing (TextAlignment(..), ColumnCount(..), textAlignmentClass)
+import SemanticUI exposing (ColumnCount(..), TextAlignment(..), textAlignmentClass)
 
 
 {-| The configuration of a column.
 -}
-type alias Config =
+type alias Config msg =
     { textAlignment : TextAlignment
     , width : ColumnCount
+    , attributes : List (Attribute msg)
     }
 
 
 {-| How text should be aligned in a column.
 -}
-textAlignment : TextAlignment -> Config -> Config
+textAlignment : TextAlignment -> Config msg -> Config msg
 textAlignment textAlignment model =
     { model | textAlignment = textAlignment }
 
 
 {-| Specify the width of a column.
 -}
-width : ColumnCount -> Config -> Config
+width : ColumnCount -> Config msg -> Config msg
 width width model =
     { model | width = width }
 
 
+{-| Specify additional attributes for a column
+-}
+attributes : List (Attribute msg) -> Config msg -> Config msg
+attributes attributes model =
+    { model | attributes = attributes }
+
+
 {-| The simplest configuration of a column.
 -}
-init : Config
+init : Config msg
 init =
     { textAlignment = LeftAligned
     , width = OneColumn
+    , attributes = []
     }


### PR DESCRIPTION
It's currently possible to specify custom attributes for a `Grid` but not for a `Column`. This PR adds the option to specify custom attributes for a column.

A use case for this is when a column contains a fixed-width element (e.g. an image). In some cases is is necessary to set `min-width` and/or `min-height` on the column to achieve the desired layout.

The addition of a `msg` parameter to `Column` affects very little existing code. The only modification required within `mono/client`, for example, is a trivial change to a single type declaration.