### PR TITLE
elm-packages.json -> elm.json

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,11 +1,9 @@
 {
-    "version": "1.0.0",
+    "type": "package",
+    "name": "circuithub/elm-semantic-ui",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/user/project.git",
-    "license": "BSD3",
-    "source-directories": [
-        "."
-    ],
+    "license": "BSD-3-Clause",
+    "version": "1.0.0",
     "exposed-modules": [
         "SemanticUI",
         "SemanticUI.Elements.Button",
@@ -25,11 +23,16 @@
         "SemanticUI.Collections.Grid",
         "SemanticUI.Collections.Grid.Column",
         "SemanticUI.Collections.Message",
+        "SemanticUI.Modules.Modal",
+        "SemanticUI.Modules.Checkbox",
         "SemanticUI.Views.Cards.Card"
     ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm-lang/core": "5.1.1 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.1.2 <= v < 2.0.0",
+        "elm-community/maybe-extra": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.18.0 <= v < 0.19.0"
+    "test-dependencies": {}
 }

--- a/elm.json
+++ b/elm.json
@@ -1,7 +1,7 @@
 {
     "type": "package",
     "name": "circuithub/elm-semantic-ui",
-    "summary": "helpful summary of your project, less than 80 characters",
+     "summary": "A reasonable type safe interface to creating Semantic UI based applications",
     "license": "BSD-3-Clause",
     "version": "1.0.0",
     "exposed-modules": [


### PR DESCRIPTION
One step closer to getting CI working.

It seems we'll need to move all modules into `src` directory though.

```
$ elm make SemanticUI/Elements/Step.elm 
-- UNKNOWN IMPORT --------------------------------- SemanticUI/Elements/Step.elm

The SemanticUI.Elements.Step module has a bad import:

    import SemanticUI.Elements.Icon

I cannot find that module! Is there a typo in the module name?

When creating a package, all modules must live in the src/ directory.
```