### PR TITLE
Expose `Pointing`'s constructors

### DIFF
--- a/src/SemanticUI/Elements/Label.elm
+++ b/src/SemanticUI/Elements/Label.elm
@@ -1,20 +1,15 @@
-module SemanticUI.Elements.Label
-    exposing
-        ( Config
-        , Pointing
-        , basic
-        , circular
-        , color
-        , detail
-        , horizontal
-        , icon
-        , image
-        , init
-        , label
-        , link
-        , pointing
-        , size
-        )
+module SemanticUI.Elements.Label exposing
+    ( label
+    , init, Config
+    , image
+    , color
+    , detail
+    , pointing, Pointing(..)
+    , basic
+    , circular
+    , size
+    , horizontal, icon, link
+    )
 
 {-| A label displays content classification.
 


### PR DESCRIPTION
So that users can use it when they call the `pointing` function.