### PR TITLE
Add SemanticUI.Modules.Dropdown.Selection.menuItem

### DIFF
--- a/src/SemanticUI/Modules/Dropdown/Select.elm
+++ b/src/SemanticUI/Modules/Dropdown/Select.elm
@@ -57,6 +57,7 @@ type Variation msg
     | Button (Button.Config msg)
     | Inline
     | Selection { compact : Bool }
+    | MenuItem
 
 
 variationClassList : Variation msg -> List ( String, Bool )
@@ -73,6 +74,9 @@ variationClassList variation =
 
         Selection { compact } ->
             [ ( "compact", compact ), ( "selection", True ) ]
+
+        MenuItem ->
+            [ ( "inline", True ), ( "item", True ) ]
 
 
 {-| Most general configuration that applies any `Select`.

--- a/src/SemanticUI/Modules/Dropdown/Selection.elm
+++ b/src/SemanticUI/Modules/Dropdown/Selection.elm
@@ -11,6 +11,7 @@ module SemanticUI.Modules.Dropdown.Selection exposing
     , inline
     , label
     , linkItem
+    , menuItem
     , scrolling
     , selection
     , single
@@ -342,6 +343,29 @@ inline config =
     Selection
         { singleConfig
             | variation = Select.Inline
+            , caret = True
+        }
+
+{-| A single selection dropdown component that can be used as a menu item.
+-}
+menuItem :
+    { config
+        | value : selection
+        , drawerState : Drawer.State
+        , identifier : String
+        , onToggle : Drawer.State -> msg
+        , onSelect : option -> msg
+        , isSelected : option -> Bool
+    }
+    -> Selection msg option selection
+menuItem config =
+    let
+        (Selection singleConfig) =
+            single config
+    in
+    Selection
+        { singleConfig
+            | variation = Select.MenuItem
             , caret = True
         }
 


### PR DESCRIPTION
This renders a selection dropdown with the `item` class, suitable for
use in `ui menu` components.